### PR TITLE
Client Stats IOCTL returns error when it is failed

### DIFF
--- a/src/lib/ioctl80211/ioctl80211_client.c
+++ b/src/lib/ioctl80211/ioctl80211_client.c
@@ -1240,7 +1240,7 @@ ioctl_status_t ioctl80211_clients_stats_fetch(
             "(Failed to retrieve them from driver '%s')",
             radio_get_name_from_type(radio_type),
             strerror(errno));
-        return IOCTL_STATUS_OK;
+        return IOCTL_STATUS_ERROR;
     }
 
     stats_entry->frames_tx = 


### PR DESCRIPTION
The issue was found when the client was disconnected just before
IEEE80211_IOCTL_STA_STATS call. So if the client is disconnected then
the succeed result is returned, but stats data structure
(Rx/Tx Bytes/Frames etc) is not filled.

Fixes: 89fbc4bc9008 ("Release 1.4.0.1")

Signed-off-by: Comcast-Serhiy-Chumak <serhiy_chumak@comcast.com>