### PR TITLE
Client Stats IOCTL returns correct Tx-bytes - 2.4G

### DIFF
--- a/src/lib/ioctl80211/ioctl80211_client.c
+++ b/src/lib/ioctl80211/ioctl80211_client.c
@@ -1244,18 +1244,14 @@ ioctl_status_t ioctl80211_clients_stats_fetch(
     }
 
     stats_entry->frames_tx = 
-        (RADIO_TYPE_5G == radio_type) ? 
-        ieee80211_client_stats.is_stats.ns_tx_data_success : 
-        ieee80211_client_stats.is_stats.ns_tx_data;
+        ieee80211_client_stats.is_stats.ns_tx_data_success;
     LOG(TRACE,
         "Parsed %s client tx_frames %u",
         radio_get_name_from_type(radio_type),
         stats_entry->frames_tx);
 
     stats_entry->bytes_tx = 
-        (RADIO_TYPE_5G == radio_type) ? 
-        ieee80211_client_stats.is_stats.ns_tx_bytes_success :
-        ieee80211_client_stats.is_stats.ns_tx_bytes;
+        ieee80211_client_stats.is_stats.ns_tx_bytes_success;
     LOG(TRACE,
         "Parsed %s client tx_bytes %"PRIu64"",
         radio_get_name_from_type(radio_type),


### PR DESCRIPTION
Client Stats IOCTL sets correct Tx-bytes/frames 2G

Tx-bytes parameter is filled in with too large value for 2.4GHz Wifi
clients when throughput test is run.
Tx-frames parameter is fixed in the same way.
The issue is caused by the legacy code which dates back to qsdk 2.0
and other very old driver bases with their quirks.
This is no longer necessary on newer qsdk releases.

Fixes: 89fbc4b ("Release 1.4.0.1")

Signed-off-by: Comcast-Serhiy-Chumak <serhiy_chumak@comcast.com>