### PR TITLE
Implement WiFi Blaster related TAPI

### DIFF
--- a/src/lib/ioctl80211/inc/ioctl80211_client.h
+++ b/src/lib/ioctl80211/inc/ioctl80211_client.h
@@ -122,4 +122,11 @@ ioctl_status_t ioctl80211_client_stats_convert(
         ioctl80211_client_record_t *data_old,
         dpp_client_record_t        *client_result);
 
+ioctl_status_t ioctl80211_client_stats_get(
+        radio_type_t                radio_type,
+        char                       *ifName,
+        char                       *phyName,
+        mac_address_t               mac,
+        dpp_client_stats_t         *stats);
+
 #endif /* IOCTL80211_CLIENT_H_INCLUDED */

--- a/src/lib/ioctl80211/inc/ioctl80211_survey.h
+++ b/src/lib/ioctl80211/inc/ioctl80211_survey.h
@@ -105,4 +105,8 @@ ioctl_status_t ioctl80211_survey_results_convert(
         ioctl80211_survey_record_t *data_old,
         dpp_survey_record_t        *survey_record);
 
+ioctl_status_t ioctl80211_survey_noise_floor_get(
+        char                       *if_name,
+        int                        *noise_floor);
+
 #endif /* IOCTL80211_SURVEY_H_INCLUDED */

--- a/src/lib/ioctl80211/ioctl80211_survey.c
+++ b/src/lib/ioctl80211/ioctl80211_survey.c
@@ -446,3 +446,22 @@ ioctl_status_t ioctl80211_survey_results_convert(
 
     return IOCTL_STATUS_OK;
 }
+
+ioctl_status_t ioctl80211_survey_noise_floor_get(
+        char                       *if_name,
+        int                        *noise_floor)
+{
+    struct iwreq iwr;
+
+    memset(&iwr, 0, sizeof(iwr));
+    strncpy(iwr.ifr_name, if_name, IFNAMSIZ);
+    iwr.u.mode = IEEE80211_PARAM_CHAN_NOISE;
+
+    if (ioctl(ioctl80211_fd_get(), IEEE80211_IOCTL_GETPARAM, &iwr) < 0) {
+        LOGE("%s: Failed to get Noise Floor for %s dev", __func__, if_name);
+        return IOCTL_STATUS_ERROR;
+    }
+
+    *noise_floor = iwr.u.param.value;
+	return IOCTL_STATUS_OK;
+}

--- a/src/lib/ioctl80211/ioctl80211_survey.c
+++ b/src/lib/ioctl80211/ioctl80211_survey.c
@@ -463,5 +463,5 @@ ioctl_status_t ioctl80211_survey_noise_floor_get(
     }
 
     *noise_floor = iwr.u.param.value;
-	return IOCTL_STATUS_OK;
+    return IOCTL_STATUS_OK;
 }

--- a/src/lib/target/target_init.c
+++ b/src/lib/target/target_init.c
@@ -44,6 +44,11 @@ struct ev_loop *target_mainloop;
 bool target_init(target_init_opt_t opt, struct ev_loop *loop)
 {
     switch (opt) {
+        case TARGET_INIT_MGR_WBM:
+            if (ioctl80211_init(loop, false) != IOCTL_STATUS_OK) {
+                return false;
+            }
+            break;
         case TARGET_INIT_MGR_SM:
             if (ioctl80211_init(loop, true) != IOCTL_STATUS_OK) {
                 return false;

--- a/src/lib/target/target_ioctl_stats.c
+++ b/src/lib/target/target_ioctl_stats.c
@@ -103,6 +103,26 @@ bool target_radio_fast_scan_enable(radio_entry_t *radio_cfg, ifname_t if_name)
     return true;
 }
 
+bool target_stats_client_get(radio_type_t radio_type,
+                             char *if_name,
+                             char *phy_name,
+                             mac_address_t mac,
+                             dpp_client_stats_t *stats)
+{
+    ioctl_status_t rc;
+    rc = ioctl80211_client_stats_get(radio_type,
+                                     if_name,
+                                     phy_name,
+                                     mac,
+                                     stats);
+    if (IOCTL_STATUS_OK != rc)
+    {
+        return false;
+    }
+
+    return true;
+}
+
 
 /******************************************************************************
  *  CLIENT definitions
@@ -209,6 +229,21 @@ bool target_stats_survey_convert(radio_entry_t *radio_cfg,
                                            data_new,
                                            data_old,
                                            survey_record);
+    if (IOCTL_STATUS_OK != rc)
+    {
+        return false;
+    }
+
+    return true;
+}
+
+bool target_stats_survey_noise_floor_get(char *ifname,
+                                         int *noise_floor)
+{
+    ioctl_status_t rc;
+
+    rc = ioctl80211_survey_noise_floor_get(ifname,
+                                           noise_floor);
     if (IOCTL_STATUS_OK != rc)
     {
         return false;


### PR DESCRIPTION
Added new TAPIs: "get WiFi Noise Floor", "get WiFi client stats".
Fixed WiFi Client Stats TAPI to be used by WiFi Blaster feature.

Note that this PR is needed by https://github.com/plume-design/opensync/pull/18

Signed-off-by: Comcast-Serhiy-Chumak <serhiy_chumak@comcast.com>