### PR TITLE
Use 64 bit fields for survey results

### DIFF
--- a/src/lib/ioctl80211/inc/ioctl80211_survey.h
+++ b/src/lib/ioctl80211/inc/ioctl80211_survey.h
@@ -41,19 +41,7 @@ typedef struct
     uint64_t                        chan_rx;
     uint64_t                        chan_tx;
     int16_t                         chan_noise;
-} ioctl80211_survey_bss_t;
-
-// off-channel survey
-typedef struct
-{
-    uint32_t                        chan_active;
-    uint32_t                        chan_busy;
-    uint32_t                        chan_busy_ext;
-    uint32_t                        chan_self;
-    uint32_t                        chan_rx;
-    uint32_t                        chan_tx;
-    int16_t                         chan_noise;
-} ioctl80211_survey_obss_t;
+} ioctl80211_survey_t;
 
 typedef struct
 {
@@ -62,8 +50,8 @@ typedef struct
 
     /* Target specific survey data */
     union {
-        ioctl80211_survey_bss_t     survey_bss;
-        ioctl80211_survey_obss_t    survey_obss;
+        ioctl80211_survey_t     survey_bss;
+        ioctl80211_survey_t    survey_obss;
     } stats;
 
     /* Linked list survey data */

--- a/src/lib/ioctl80211/ioctl80211_survey.c
+++ b/src/lib/ioctl80211/ioctl80211_survey.c
@@ -344,7 +344,7 @@ ioctl_status_t ioctl80211_survey_results_convert(
 
     /* Loop through all configured channels */
     if (scan_type == RADIO_SCAN_TYPE_ONCHAN) {
-        ioctl80211_survey_bss_t     data;
+        ioctl80211_survey_t     data;
 
 
         data.chan_active = STATS_DELTA(
@@ -398,7 +398,7 @@ ioctl_status_t ioctl80211_survey_results_convert(
         survey_record->duration_ms   = data.chan_active / 1000;
         survey_record->chan_noise   = data.chan_noise;
     } else { /* OFF and FULL */
-        ioctl80211_survey_obss_t     data;
+        ioctl80211_survey_t     data;
 
         data.chan_active = STATS_DELTA(
                 data_new->stats.survey_obss.chan_active,

--- a/src/lib/ioctl80211/ioctl80211_survey_11ax.c
+++ b/src/lib/ioctl80211/ioctl80211_survey_11ax.c
@@ -308,7 +308,7 @@ ioctl_status_t ioctl80211_survey_results_get(
                 survey_record->stats.survey_obss.chan_busy_ext = 0;
 
                 LOGT("Fetched %s %s %u survey "
-                     "{active=%u busy=%u tx=%u self=%u rx=%u ext=%u}",
+                     "{active=%"PRIu64" busy=%"PRIu64" tx=%"PRIu64" self=%"PRIu64" rx=%"PRIu64" ext=%"PRIu64"}",
                      radio_get_name_from_type(radio_type),
                      radio_get_scan_name_from_type(scan_type),
                      survey_record->info.chan,
@@ -358,7 +358,7 @@ ioctl_status_t ioctl80211_survey_results_convert(
 
     /* Loop through all configured channels */
     if (scan_type == RADIO_SCAN_TYPE_ONCHAN) {
-        ioctl80211_survey_bss_t     data;
+        ioctl80211_survey_t     data;
 
 
         data.chan_active = STATS_DELTA(
@@ -409,7 +409,7 @@ ioctl_status_t ioctl80211_survey_results_convert(
             STATS_PERCENT(data.chan_busy_ext, data.chan_active);
         survey_record->duration_ms   = data.chan_active / 1000;
     } else { /* OFF and FULL */
-        ioctl80211_survey_obss_t     data;
+        ioctl80211_survey_t     data;
 
         data.chan_active = STATS_DELTA(
                 data_new->stats.survey_obss.chan_active,
@@ -427,7 +427,7 @@ ioctl_status_t ioctl80211_survey_results_convert(
         data.chan_busy_ext = 0;
 
         LOGT("Processed %s %s %u survey delta "
-             "{active=%u busy=%u tx=%u self=%u rx=%u ext=%u}",
+             "{active=%"PRIu64" busy=%"PRIu64" tx=%"PRIu64" self=%"PRIu64" rx=%"PRIu64" ext=%"PRIu64"}",
              radio_get_name_from_type(radio_type),
              radio_get_scan_name_from_type(scan_type),
              data_new->info.chan,


### PR DESCRIPTION
These were truncated with normal survey data, causing erroneous
warnings that busy is less than RX, among others.
The structure has the same fields as BSS, so just use that everywhere.